### PR TITLE
Modified contributor code of conduct

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -58,8 +58,8 @@ There are several ways you can get involved:
 Contributions Acknowledgement
 -----------------------------
 
-Any contributions to this documentation will be listed in the front page, just below
-the authors.
+Any contributions to this documentation will be listed on the front page, below
+the creators list.
 
 Contributions to other repository (i.e phconvert, reading examples) will be 
 acknowledged in the respective website and listed in their ``LICENSE`` files.
@@ -70,15 +70,10 @@ All the code in Photon-HDF5 projects is released under the
 Contributor Code of Conduct
 ---------------------------
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+[I don't think harassment, sexual inuendos or racial slur is to be feared in the near future. This kind of warning is more appropriate for forums with a wide and diverse audience. PLus only members of the organization can modify anything, right?]
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+As maintainers of this project, we welcome all contributions such as reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+[do you need to be granted membership to the Photon-HDF5 organization?].
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
-
-This Code of Conduct is adapted from the Contributor Covenant, version 1.0.0, available from 
-http://contributor-covenant.org/version/1/0/0/.
+However, we reserve the right to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions which do not respect basic decency rules (such as epxressed in the Contributor Covenant, version 1.0.0, available from http://contributor-covenant.org/version/1/0/0/.)


### PR DESCRIPTION
I think the original version is more appropriate for a wide audience forum, not for a scientific collaboration project, where it is very unlikely that we will encounter any of these issues.
