### PR TITLE
Minor edits in the Detector Pixel ID paragraph

### DIFF
--- a/docs/phdata.rst
+++ b/docs/phdata.rst
@@ -422,7 +422,9 @@ Detector pixel IDs
 ^^^^^^^^^^^^^^^^^^
 
 A *detector pixel ID* (or simply *pixel ID*) is the "name" of each pixels and
-is typically a single integer and pixels are numbered with a progressive index.
+is usually a single integer. Pixels are normally numbered incrementally, but not necessarily so.
+In other words, a file containing data taken with 2 single-point (pixel) detectors could have
+the first detector labeled "4" and the second detector labeled "6".
 In some cases (when using detector arrays) the pixel ID
 can be a *n*-tuple of integers. This allow to specify, for each pixel,
 the module number and the X, Y location, for example. Therefore, an


### PR DESCRIPTION
If I understand correctly, the 2-D array caveat applies for the Polarization and Split Channel lists.
I would suggest having a flag telling that this is the case (i.e. providing information on the dimension of the Pixel ID), in order to simplify the task of the programmer (reader).
